### PR TITLE
Update clave.tokenlist.zksync-mainnet.json

### DIFF
--- a/token-list/clave.tokenlist.zksync-mainnet.json
+++ b/token-list/clave.tokenlist.zksync-mainnet.json
@@ -37,7 +37,7 @@
       "name": "BuidlBucks",
       "symbol": "BUIDL",
       "decimals": 18,
-      "address": "0x84706f5fcbec6d5b4adb01a277dcca2f6f5cad26",
+      "address": "0xccfad26c904c086b9ad78d624b8afa922416b73f",
       "icon": "https://raw.githubusercontent.com/getclave/clave-lists/master/token-list/logos/0xccfad26c904c086b9ad78d624b8afa922416b73f.png",
       "type": "ERC20",
       "isDefault": true


### PR DESCRIPTION
Updates BUIDL address to 0xccfad26c904c086b9ad78d624b8afa922416b73f